### PR TITLE
Changed JFrog Validation

### DIFF
--- a/vars/jfrog.groovy
+++ b/vars/jfrog.groovy
@@ -15,11 +15,11 @@ def jfrogXray(Map properties=[:]) {
 
     logger.info("JFrog XRay Scan")
     // jfrogPublishBuild(properties)
-    withCredentials([string(credentialsId: "JfrogArt-SA-ro-Token", variable: "TOKEN")]) {
+    withCredentials([usernamePassword(credentialsId: "kaniko-jfrog-sa-rw", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
         try {
             sh"""
                 apk add --no-cache bash jq
-                jf c add cms-artifactory --url=https://artifactory.cloud.cms.gov/ --access-token=${TOKEN}
+                jf c add cms-artifactory --url=https://artifactory.cloud.cms.gov/ --user=${USERNAME} --password=${PASSWORD}
             """
             def result = sh(script: "jf xr curl '/api/v1/artifacts?search=${searchPath}' | jq '.data[0].sec_issues'", returnStdout: true).trim()
             logger.info("XRay Scan Result: ${result}")
@@ -43,7 +43,7 @@ def jfrogRunXray(Map properties=[:], String repoName) {
 
 def imageScan(Map properties=[:], String repoName) {
     logger.info("Running new Image XRay Scan")
-    withCredentials([string(credentialsId: "JfrogArt-SA-ro-Token", variable: "TOKEN")]) {
+    withCredentials([usernamePassword(credentialsId: "kaniko-jfrog-sa-rw", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
         sh "jf xr curl '/api/v1/scanArtifact' --header 'Content-Type: application/json' --data '{ \"componentID\": \"docker://${properties.artifactName}:${env.GIT_COMMIT}\"}'"
 
         def status = sh(script: "jf xr curl '/api/v1/artifact/status' --header 'Content-Type: application/json' --data '{ \"repo\": \"${repoName}\", \"path\": \"${properties.artifactName}/${env.GIT_COMMIT}/manifest.json\"}' | jq -r '.overall.status'", returnStdout: true).trim()
@@ -69,7 +69,7 @@ def zipScan(Map properties=[:], String repoName) {
     // return
 
     logger.info("Running new Zip XRay Scan")
-    withCredentials([string(credentialsId: "JfrogArt-SA-ro-Token", variable: "TOKEN")]) {
+    withCredentials([usernamePassword(credentialsId: "kaniko-jfrog-sa-rw", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
         sh "jf xr curl 'api/v2/index' --header 'Content-Type: application/json' --data '{   \"repo_path\":\"${properties.artifactPackagePath}/${properties.build.fileName}\"     }'"
     
         def status = sh(script: "jf xr curl '/api/v1/artifact/status' --header 'Content-Type: application/json' --data '{ \"repo\": \"${repoName}\", \"path\": \"${properties.artifactName}/${properties.build.fileName}\"}' | jq -r '.overall.status'", returnStdout: true).trim()
@@ -95,8 +95,8 @@ def upload(Map properties=[:]) {
         logger.info("Dockerfile provided, skipping manual upload")
         return
     }
-    withCredentials([string(credentialsId: "JfrogArt-SA-ro-Token", variable: 'TOKEN')]) {
-        sh "jf rt u --url=https://artifactory.cloud.cms.gov/artifactory --access-token ${TOKEN} ${properties.build.fileName} ${properties.artifactPackagePath}/${properties.build.fileName} --build-name=${properties.artifactName} --build-number=${env.GIT_COMMIT}"
+    withCredentials([usernamePassword(credentialsId: "kaniko-jfrog-sa-rw", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+        sh "jf rt u --url=https://artifactory.cloud.cms.gov/artifactory --user=${USERNAME} --password=${PASSWORD} ${properties.build.fileName} ${properties.artifactPackagePath}/${properties.build.fileName} --build-name=${properties.artifactName} --build-number=${env.GIT_COMMIT}"
     }
 }
 
@@ -116,59 +116,59 @@ def jfrogRefreshToken(String refreshedToken) {
     }
 }
 
-def buildPublish(Map parameters=[:]) {
-    //Optional functionality. Return if non-container build
-    if(CONTAINER_BUILD ==~ /(?i)(false|FALSE)/) { return }
-    logger.debug("Debug buildpublish:${parameters}")
-    logger.info("buildPublish Initiated")
-    def Map defaults = digestParameters()
-    withCredentials([string(credentialsId: "${env.artifactoryCredentialId}", variable: 'TOKEN')]) {
-        sh "jfrog rt bp --url ${defaults.url} --access-token ${TOKEN} --build-url ${env.JOB_URL} ${env.JOB_NAME} ${env.BUILD_NUMBER}"
-        //Publish the captured build info
-        //Likely run after a Kaniko build
-        //https://github.com/jfrogrog/project-examples/tree/master/docker-oci-examples/kaniko-example
-        //Leave this here to be available, but call in Kaniko?
-    }
-}
+// def buildPublish(Map parameters=[:]) {
+//     //Optional functionality. Return if non-container build
+//     if(CONTAINER_BUILD ==~ /(?i)(false|FALSE)/) { return }
+//     logger.debug("Debug buildpublish:${parameters}")
+//     logger.info("buildPublish Initiated")
+//     def Map defaults = digestParameters()
+//     withCredentials([string(credentialsId: "${env.artifactoryCredentialId}", variable: 'TOKEN')]) {
+//         sh "jfrog rt bp --url ${defaults.url} --access-token ${TOKEN} --build-url ${env.JOB_URL} ${env.JOB_NAME} ${env.BUILD_NUMBER}"
+//         //Publish the captured build info
+//         //Likely run after a Kaniko build
+//         //https://github.com/jfrogrog/project-examples/tree/master/docker-oci-examples/kaniko-example
+//         //Leave this here to be available, but call in Kaniko?
+//     }
+// }
 
-def buildDockerCreate(Map parameters=[:], multiTags = false, tagFile = ""){ //multiTag and tagFile used for buildDockerCreateAndPublish
-    //Optional functionality. Return if non-container build
-    if(CONTAINER_BUILD ==~ /(?i)(false|FALSE)/) { return }
-    logger.info("buildDockerCreate Initiated")
-    def Map defaults = digestParameters()
-    logger.info("env.JOB_NAME: ${env.JOB_NAME}")
-    logger.info("env.BUILD_NUMBER: ${env.BUILD_NUMBER}")
-    logger.info("parameters.appName: ${parameters.appName}")
-    logger.info("parameters.build.repo: ${parameters.build.repo}")
-    withCredentials([string(credentialsId: "${env.artifactoryCredentialId}", variable: 'TOKEN')]) {
-        //If calling from buildDockerCreateAndPublish, we're using multiple tags, so we want to pass a different image-file each time.
-        if (multiTags == false) {
-            sh "jfrog rt bdc --url ${defaults.url} --access-token ${TOKEN} ${parameters.build.repo} --image-file ${parameters.appName}-file-details --build-name=${env.JOB_NAME} --build-number=${env.BUILD_NUMBER}"
-        }
-        else {
-            sh "jfrog rt bdc --url ${defaults.url} --access-token ${TOKEN} ${parameters.build.repo} --image-file ${tagFile} --build-name=${env.JOB_NAME} --build-number=${env.BUILD_NUMBER}"
-        }
-    }
-}
-def buildDockerCreateAndPublish(Map parameters=[:]){
-    //Optional functionality. Return if non-container build
-    if(CONTAINER_BUILD ==~ /(?i)(false|FALSE)/) { return }
-    logger.info("buildDockerCreateAndPublish Initiated")
-    // Split the file-details file into multiple files one for each tag, then call buildDockerCreate for each one.
-    sh "split -l 1 ${parameters.appName}-file-details tag-"
-    tagFiles = sh(returnStdout: true, script: "ls -1 tag-*").trim()
-    for (file in tagFiles.split('\n')) {
-        buildDockerCreate(parameters, true, file)
-        buildPublish(parameters)
-    }
-}
+// def buildDockerCreate(Map parameters=[:], multiTags = false, tagFile = ""){ //multiTag and tagFile used for buildDockerCreateAndPublish
+//     //Optional functionality. Return if non-container build
+//     if(CONTAINER_BUILD ==~ /(?i)(false|FALSE)/) { return }
+//     logger.info("buildDockerCreate Initiated")
+//     def Map defaults = digestParameters()
+//     logger.info("env.JOB_NAME: ${env.JOB_NAME}")
+//     logger.info("env.BUILD_NUMBER: ${env.BUILD_NUMBER}")
+//     logger.info("parameters.appName: ${parameters.appName}")
+//     logger.info("parameters.build.repo: ${parameters.build.repo}")
+//     withCredentials([string(credentialsId: "${env.artifactoryCredentialId}", variable: 'TOKEN')]) {
+//         //If calling from buildDockerCreateAndPublish, we're using multiple tags, so we want to pass a different image-file each time.
+//         if (multiTags == false) {
+//             sh "jfrog rt bdc --url ${defaults.url} --access-token ${TOKEN} ${parameters.build.repo} --image-file ${parameters.appName}-file-details --build-name=${env.JOB_NAME} --build-number=${env.BUILD_NUMBER}"
+//         }
+//         else {
+//             sh "jfrog rt bdc --url ${defaults.url} --access-token ${TOKEN} ${parameters.build.repo} --image-file ${tagFile} --build-name=${env.JOB_NAME} --build-number=${env.BUILD_NUMBER}"
+//         }
+//     }
+// }
+// def buildDockerCreateAndPublish(Map parameters=[:]){
+//     //Optional functionality. Return if non-container build
+//     if(CONTAINER_BUILD ==~ /(?i)(false|FALSE)/) { return }
+//     logger.info("buildDockerCreateAndPublish Initiated")
+//     // Split the file-details file into multiple files one for each tag, then call buildDockerCreate for each one.
+//     sh "split -l 1 ${parameters.appName}-file-details tag-"
+//     tagFiles = sh(returnStdout: true, script: "ls -1 tag-*").trim()
+//     for (file in tagFiles.split('\n')) {
+//         buildDockerCreate(parameters, true, file)
+//         buildPublish(parameters)
+//     }
+// }
 
-def jfrogPublishBuild(Map properties=[:]) {
-    logger.info("Publish build to JFrog")
-    withCredentials([string(credentialsId: "JfrogArt-SA-ro-Token", variable: "TOKEN")]) {
-        sh"""
-            jf rt bce --project=${properties.artifactoryProjectName} ${properties.artifactName} ${env.GIT_COMMIT}
-            jf rt bp --url=https://artifactory.cloud.cms.gov/artifactory --access-token=${TOKEN} --project=${properties.artifactoryProjectName} ${properties.artifactName} ${env.GIT_COMMIT}
-        """
-    }
-}
+// def jfrogPublishBuild(Map properties=[:]) {
+//     logger.info("Publish build to JFrog")
+//     withCredentials([string(credentialsId: "JfrogArt-SA-ro-Token", variable: "TOKEN")]) {
+//         sh"""
+//             jf rt bce --project=${properties.artifactoryProjectName} ${properties.artifactName} ${env.GIT_COMMIT}
+//             jf rt bp --url=https://artifactory.cloud.cms.gov/artifactory --access-token=${TOKEN} --project=${properties.artifactoryProjectName} ${properties.artifactName} ${env.GIT_COMMIT}
+//         """
+//     }
+// }


### PR DESCRIPTION
Validating JFrog connection with kaniko-jfrog-sa-rw instead of JfrogArt-SA-ro-Token.
Commented out some currently unused functions.

Tested in below pipeline to ensure authorization:
https://jenkins-dev-east.cloud.cms.gov/devops/job/test-dotNet/job/dotnetcore6-std/133/console